### PR TITLE
Missing attribute to allow multiple

### DIFF
--- a/ItemBinding/Model/BindingContracts/CompositeTypeAttribute.cs
+++ b/ItemBinding/Model/BindingContracts/CompositeTypeAttribute.cs
@@ -2,6 +2,7 @@
 
 namespace ItemBinding.Model.BindingContracts
 {
+  [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
   public class CompositeTypeAttribute : Attribute
   {
     public CompositeTypeAttribute(Type type)


### PR DESCRIPTION
Hi,

I think the attribute to allow multiple CompositeType attributes to be used on a class was missing.

Thanks!

Paul
