### PR TITLE
Added check to prevent the user-control from being databound when model is null

### DIFF
--- a/ItemBinding/Presentation/ModelBoundUserControl.cs
+++ b/ItemBinding/Presentation/ModelBoundUserControl.cs
@@ -106,6 +106,17 @@ namespace ItemBinding.Presentation
     /// </value>
     protected virtual Boolean DatabindOnInit { get { return true; } }
 
+	/// <summary>
+    /// Binds a data source to the invoked server control and all its child controls.
+    /// </summary>
+	public override void DataBind()
+    {
+      if (Model == null)
+        return;
+
+      base.DataBind();
+    }
+	
     /// <summary>
     /// Raises the <see cref="E:System.Web.UI.Control.DataBinding" /> event.
     /// </summary>


### PR DESCRIPTION
Added check to prevent the user-control from being databound, given the underlaying model is null.

This fix solves a bug where the user-control inheriting from `ModelBoundUserControl` could throw an null-reference exception, given that a user had forcefully removed the underlaying datasource, after the control was inserted.
